### PR TITLE
Bump version of analysis-model to 10.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>https://github.com/jenkinsci/analysis-model</url>
 
   <properties>
-    <revision>10.2.2</revision>
+    <revision>10.2.4</revision>
     <changelist>-SNAPSHOT</changelist>
     <analysis-model.version>10.2.2</analysis-model.version>
     <plugin-util-api.version>2.1.0</plugin-util-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>https://github.com/jenkinsci/analysis-model</url>
 
   <properties>
-    <revision>10.3.0</revision>
+    <revision>10.2.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <analysis-model.version>10.2.1</analysis-model.version>
     <plugin-util-api.version>2.1.0</plugin-util-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <revision>10.2.2</revision>
     <changelist>-SNAPSHOT</changelist>
-    <analysis-model.version>10.2.1</analysis-model.version>
+    <analysis-model.version>10.2.2</analysis-model.version>
     <plugin-util-api.version>2.1.0</plugin-util-api.version>
   </properties>
 


### PR DESCRIPTION
See https://github.com/jenkinsci/analysis-model/releases/tag/v10.2.2.