### PR TITLE
Enable jdk11 build on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,7 @@ List<Map<String, String>> getConfigurations(Map params) {
     if (explicit) return params.configurations
 
     def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
-    def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : [8]
+    def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : [8,11]
     def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
 
     def ret = []


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I am trying to validate if plugins that are used by customer are jdk11 compatible. I have looked at the CI on the master branch, I see only jdk8 steps.
I try to add jdk11, but as I don't know this Jenkinsfile I am not sure I am doing it the right way. Also as I am not one maintainer, this Jenkinsfile is not going to be executed on my PR.

I also see that a lot of plugin are using a very short Jenkinsfile with only `buildPlugin`, if you think this Jenkinsfile could use buildPlugin I can try to migrate it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
