### PR TITLE
[JENKINS-68448] Prepare Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
       <artifactId>plugin-util-api</artifactId>
       <version>${plugin-util-api.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.6-1</version>
+    </dependency>
   </dependencies>
 
   <scm>
@@ -115,4 +120,3 @@
   </pluginRepositories>
 
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
-      <version>2.3.0.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
-      <version>2.3.6-1</version>
+      <version>2.3.0.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Explicitely declares JAXB plugin as a dependency.

See [JENKINS-68448](https://issues.jenkins.io/browse/JENKINS-68448).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
