### PR TITLE
Declare explicit dependency on apache-httpcomponents plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,14 @@
   </developers>
 
   <dependencies>
+    <!--
+      https://plugins.jenkins.io/apache-httpcomponents-client-4-api/#plugin-content-plugins-using-libraries-depending-on-httpclient
+      Recent versions of Saxon bring in httpcomponents (spotbugs -> saxon-he -> xmlresolver -> httpclient)
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>edu.hm.hafner</groupId>
       <artifactId>analysis-model</artifactId>


### PR DESCRIPTION
This avoids using/bundling the transitive version brought in by newer spotbugs

This is one possible solution to https://issues.jenkins.io/browse/JENKINS-69640.  If the http libraries are *actually* used, other solutions might be more appropriate (i.e., shading them).  This PR assumes that *if* the libraries are needed, that the versions provided by the wrapper plugin are "good enough".  Presumably the library had previously been working fine with [whatever the consumer happened to provide](https://saxonica.plan.io/issues/5265), and there's no obvious indications that that has changed.  This PR uses the [recommended](https://plugins.jenkins.io/apache-httpcomponents-client-4-api/#plugin-content-plugins-using-libraries-depending-on-httpclient) technique for plugins indirectly using these libraries.

The upgrade of spotbugs in https://github.com/jenkinsci/analysis-model-api-plugin/pull/90 is what led to saxon's 'new' dependencies being bundled.

Due to the nature of the issue it didn't seem like tests were warranted (in this project at least).  If this is the desired/acceptable solution but tests are still desired, let me know and I'll see what I can do.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
