### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def configurations = [
-  [ platform: "linux", jdk: "11" ],
-  [ platform: "windows", jdk: "11" ]
+  [ platform: "linux", jdk: 21 ],
+  [ platform: "windows", jdk: 17 ]
 ]
 
 buildPlugin(failFast: false, configurations: configurations,


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Not testing Java 11 because Java 11 byte code is being generated by the Java 17 compiler and the Java 21 compiler.  The plugin bill of materials runs the tests with Java 11 as well.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024.  We'll need to move past Java 11 by that time, so this makes the transition in test configuration.  It does not change the supported Java version or the byte code that is being generated.

### Testing done

Confirmed that tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
