### PR TITLE
Use BOM versions for all dependencies marked with a TODO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsoup</artifactId>
       <!-- TODO: remove the version when a matching BOM is available -->
-      <version>1.18.3-30.v952e9442d416</version>
+      <version>1.19.1-36.v63b_c859911d0</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -80,8 +80,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <!-- TODO: remove the version when a matching BOM is available -->
-      <version>6.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Jenkins BOM contains all correct versions again.