### PR TITLE
Fixes project configuration URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <packaging>hpi</packaging>
   <name>Analysis Model API Plugin</name>
   <description>Static Analysis Model and Parsers API used by the Warnings plugin.</description>
-  <url>https://github.com/jenkinsci/analysis-model</url>
+  <url>https://github.com/jenkinsci/analysis-model-api-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
The `project.url` value is used in the `jenkins-infra/update-center2` project to build the `plugin-documentation-urls.json`. This file is used by Plugin Health Scoring to determine if a plugin has migrated its documentation from wiki or not.

Because of this value is not pointing to the plugin repository, PHS is considering that the plugin has not migrated its configuration.

<!-- Please describe your pull request here. -->

### Testing done

None.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
