### PR TITLE
Add `edu.hm.hafner.analysis.Location` to the whitelisted classes

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -3,5 +3,6 @@ edu.hm.hafner.analysis.Report
 edu.hm.hafner.analysis.Issue
 edu.hm.hafner.analysis.DuplicationGroup
 edu.hm.hafner.analysis.RevApiInfoExtension
+edu.hm.hafner.analysis.Location
 edu.hm.hafner.util.LineRange
 edu.hm.hafner.util.LineRangeList


### PR DESCRIPTION
This class is new in analysis-model 14.x.