### PR TITLE
Remove JAXB dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,6 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jaxb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
       <artifactId>json-api</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
JAXB pulls in some unwanted transitive dependencies. Since no other library depends on it, it looks ok to remove the dependeny.