### PR TITLE
Revert Saxon HE upgrade to 13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>net.sf.saxon</groupId>
         <artifactId>Saxon-HE</artifactId>
-        <version>13.0</version>
+        <version>12.9</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
Revert pull request #264. Analysis model is still based on Saxon HE 12.9.

This reverts commit 58bf31163e7e96f2d6fe06480b3d423b712bcf71, reversing changes made to 408a383cb94dc3e4c089bc32925bbba5035295bd.

Fixes #265 